### PR TITLE
Fix BOARD_PHY_ID to compile with current ChibiOS

### DIFF
--- a/board.h
+++ b/board.h
@@ -42,7 +42,7 @@
 /*
  * Ethernet PHY type.
  */
-#define BOARD_PHY_ID            MII_LAN8720A_ID
+#define BOARD_PHY_ID            MII_LAN8720_ID
 #define BOARD_PHY_RMII
 
 /*


### PR DESCRIPTION
The ChibiOS-HAL calls the PHY MII_LAN8720_ID rather than MII_LAN8720A_ID.  I've tested this code on the board and it works.
